### PR TITLE
fix: gitHub workflow go version issues

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: ../cli/go.mod
+          go-version: 1.21
+          check-latest: true
 
       - name: Installing Kurtosis CLI and starting the kurtosis engine
         run: |
@@ -48,3 +49,8 @@ jobs:
         run: |
           $DIVE_BINARY_PATH clean
           $DIVE_BINARY_PATH bridge btp --chainA icon --chainB icon --verbose
+
+      - name: Test bridge between archway and archway 
+        run: |
+            $DIVE_BINARY_PATH clean
+            $DIVE_BINARY_PATH bridge ibc --chainA archway --chainB archway --verbose

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.1
+          go-version-file: ../cli/go.mod
 
       - name: Installing Kurtosis CLI and starting the kurtosis engine
         run: |


### PR DESCRIPTION
## Description:

### Commit Message

```bash
fix: update  gitHub workflow and bump go version to 1.21 to fix gh action issues 
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: update go version 1.21 in github actions  workflow to run smoke test
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
