### PR TITLE
fix: replace plan.assert with plan.verify

### DIFF
--- a/services/jvm/icon/src/node-setup/setup_icon_node.star
+++ b/services/jvm/icon/src/node-setup/setup_icon_node.star
@@ -63,7 +63,7 @@ def register_prep(plan,service_name,name,uri,keystorepath,keypassword,nid):
 
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     plan.print("Completed RegisterPrep")
 
@@ -99,7 +99,7 @@ def set_stake(plan,service_name,amount,uri,keystorepath,keypassword,nid):
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     plan.print("Set Stake Completed")
 
@@ -115,7 +115,7 @@ def set_delegation(plan,service_name,address,amount,uri,keystorepath,keypassword
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 # Sets the bonder list with `address` specified
 def set_bonder_list(plan,service_name,address,uri,keystorepath,keypassword,nid):
@@ -128,7 +128,7 @@ def set_bonder_list(plan,service_name,address,uri,keystorepath,keypassword,nid):
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 # Sets Bond `amount` to `address`
 def set_bond(plan,service_name,address,amount,uri,keystorepath,keypassword,nid):
@@ -142,7 +142,7 @@ def set_bond(plan,service_name,address,amount,uri,keystorepath,keypassword,nid):
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 # Returns Network revision
 def get_revision(plan,service_name):
@@ -173,7 +173,7 @@ def set_revision(plan,service_name,uri,code,keystorepath,keypassword,nid):
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 # Returns PREP Node Publci Key using `address` specified
 def get_prep_node_public_key(plan,service_name,address):
@@ -202,7 +202,7 @@ def register_prep_node_publickey(plan,service_name,address,pubkey,uri,keystorepa
     tx_hash = result["output"]
     tx_result = get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 # Start decentralisation for btp relay
 def ensure_decentralisation(plan,service_name,prep_address,uri,keystorepath,keypassword,nid):
@@ -321,7 +321,7 @@ def open_btp_network(plan,service_name,args,uri,keystorepath,keypassword,nid):
     tx_hash = result["output"]
     tx_result = filter_event(plan,service_name,tx_hash)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     return tx_result
 

--- a/services/jvm/icon/src/relay-setup/contract_configuration.star
+++ b/services/jvm/icon/src/relay-setup/contract_configuration.star
@@ -44,7 +44,7 @@ def add_service(plan,bmc_address,xcall_address,args):
 
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
 
 
@@ -94,7 +94,7 @@ def add_verifier(plan,service_name,bmc_address,dst_chain_network,bmv_address,uri
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
     return tx_result
 
 # Adds BTP Link to BMC contract on ICON
@@ -111,7 +111,7 @@ def add_btp_link(plan,service_name,bmc_address,dst_bmc_address,src_network_id,ur
 
 
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     return tx_result
 
@@ -126,7 +126,7 @@ def add_relay(plan,service_name,bmc_address,dst_bmc_address,relay_address,uri,ke
 
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
     return tx_result
 
 # Configures Link in BMC on ICON
@@ -247,7 +247,7 @@ def add_connection_xcall_dapp(plan,xcall_dapp_address,wasm_network_id,java_xcall
 
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
     return tx_result
 
 def configure_xcall_connection(plan,xcall_connection_address,connection_id,counterparty_port_id,counterparty_nid,client_id,service_name,uri,keystorepath,keypassword,nid):
@@ -263,7 +263,7 @@ def configure_xcall_connection(plan,xcall_connection_address,connection_id,count
 
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
     return tx_result
 
 
@@ -279,7 +279,7 @@ def set_default_connection_xcall(plan,xcall_address,wasm_network_id,xcall_connec
     plan.print(params)
     tx_hash = result["output"].replace('"',"")
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
     return tx_result
 
 def setup_contracts_for_ibc_java(plan,args):
@@ -343,7 +343,7 @@ def registerClient(plan,service_name, light_client_address, keystorepath,keystor
     # tx_result = get_tx_result(plan,tx_hash,service_name,)
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     return tx_hash
 
@@ -362,6 +362,6 @@ def bindPort(plan,service_name,xcall_conn_address,keystorepath,keystore_password
     tx_hash = result["output"]
     tx_result = node_service.get_tx_result(plan,service_name,tx_hash,uri)
 
-    plan.assert(value=tx_result["extract.status"],assertion="==",target_value="0x1")
+    plan.verify(value=tx_result["extract.status"],assertion="==",target_value="0x1")
 
     return tx_hash


### PR DESCRIPTION
## Description:

Kurtosis is renaming plan.assert to plan.verify so popular Python linters & formatters can be run on .star scripts. We will be shipping a formatter with Kurtosis soon.

This change will work when the following - https://github.com/kurtosis-tech/kurtosis/pull/1295 is merged & released