### PR TITLE
chore: bump kurtosis sdk version to v0.83.2

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/fatih/color v1.15.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/kurtosis-tech/kurtosis/api/golang v0.82.6
+	github.com/kurtosis-tech/kurtosis/api/golang v0.83.2
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
## Description:
updated the kurtosis api version in the cli

### Commit Message

```bash
chore: bump kurtosis sdk version to v0.83.2
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
