### PR TITLE
fix: update dive eth package to work with latest eth-network-package 

### DIFF
--- a/services/evm/eth/src/node-setup/start-eth-node.star
+++ b/services/evm/eth/src/node-setup/start-eth-node.star
@@ -9,7 +9,7 @@ network_keys_and_public_address = constants.NETWORK_PORT_KEYS_AND_IP_ADDRESS
 # Spins Up the ETH Node
 def start_eth_node(plan,args):
  	eth_contstants = constants.ETH_NODE_CLIENT
- 	args_with_right_defaults = input_parser.parse_input(args)
+ 	args_with_right_defaults = input_parser.get_args_with_default_values(args)
  	num_participants = len(args_with_right_defaults.participants)
  	network_params = args_with_right_defaults.network_params
 


### PR DESCRIPTION
## Description:
kurtosis splitted the parse input function into two section in eth package
### Commit Message

```bash
fix: update dive eth package to work with latest eth-network-package 
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
