### PR TITLE
chore: bump kurtosis sdk version to 0.84.8 and bump dive cli version

### DIFF
--- a/cli/common/constants.go
+++ b/cli/common/constants.go
@@ -3,7 +3,7 @@ package common
 var DiveLogs bool
 
 // !!!!!!!!!!! DO NOT UPDATE! WILL BE UPDATED DURING THE RELEASE PROCESS !!!!!!!!!!!!!!!!!!!!!!
-var DiveVersion = "v0.0.12-beta"
+var DiveVersion = "v0.0.13-beta"
 
 const (
 	DiveEnclave                  = "dive"

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/fatih/color v1.15.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/kurtosis-tech/kurtosis/api/golang v0.84.0
+	github.com/kurtosis-tech/kurtosis/api/golang v0.84.8
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
## Description:

### Commit Message

```bash
chore: bump kurtosis sdk version to 0.84.8 and bump dive cli version
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: bump kurtosis sdk version to 0.84.8
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
