### PR TITLE
feat: implement starting collator local node with custom keys

### DIFF
--- a/cli/cmd/chains/polkadot/cmd.go
+++ b/cli/cmd/chains/polkadot/cmd.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	polkadotParachains = []string{"acala", "ajuna", "bifrost", "centrifuge", "clover", "frequency", "kilt", "kylin", "litentry", "manta", "moonbeam", "moonsama", "nodle", "parallel", "pendulum", "phala", "polkadex", "subsocial", "zeitgeist"}
+	polkadotParachains = []string{"acala", "ajuna", "bifrost", "centrifuge", "clover", "frequency", "kilt", "kylin", "litentry", "manta", "moonbeam", "moonsama", "nodle", "parallel", "pendulum", "phala", "polkadex", "subsocial", "zeitgeist", "robonomics"}
 )
 
 var PolkadotCmd = common.NewDiveCommandBuilder().

--- a/cli/cmd/chains/polkadot/run.go
+++ b/cli/cmd/chains/polkadot/run.go
@@ -386,7 +386,7 @@ func startExplorer(cli *common.Cli, enclaveCtx *enclaves.EnclaveContext, finalRe
 	}
 
 	isLocalContext, err := cli.Context().IsLocalKurtosisContext()
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/chains/utils/types.go
+++ b/cli/cmd/chains/utils/types.go
@@ -193,11 +193,17 @@ func (sc *HardhatServiceConfig) EncodeToString() (string, error) {
 
 // This code is for polkadot config file
 
+type Key struct {
+	PrivatePhrase string `json:"private_phrase"`
+	PublicKey     string `json:"public_key"`
+}
+
 type NodeConfig struct {
 	Name       string `json:"name"`
 	NodeType   string `json:"node_type"`
 	Prometheus bool   `json:"prometheus"`
 	Ports      Ports  `json:"ports"`
+	Key        Key    `json:"key,omitempty"`
 }
 
 type Ports struct {
@@ -215,6 +221,8 @@ type RelayChainConfig struct {
 type ParaNodeConfig struct {
 	Name  string       `json:"name"`
 	Nodes []NodeConfig `json:"nodes"`
+	SudoKey  Key          `json:"sudo_key,omitempty"`
+
 }
 
 type PolkadotServiceConfig struct {
@@ -222,6 +230,7 @@ type PolkadotServiceConfig struct {
 	RelayChain RelayChainConfig `json:"relaychain"`
 	Para       []ParaNodeConfig `json:"parachains"`
 	Explorer   bool             `json:"explorer"`
+	WithoutRegistration bool               `json:"without_registration"`
 }
 
 func (pc *ParaNodeConfig) EncodeToString() (string, error) {


### PR DESCRIPTION
## Description:

### Commit Message

```bash
feat: implement starting collator local node with custom keys
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
1: user can start polkadot/kusama local parachain collator node with his own keys
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
